### PR TITLE
avoid panic in discover when no st link is connected and add examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 src/bin/
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "libloading"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +28,7 @@ dependencies = [
 name = "stm32cubeprog-rs"
 version = "0.0.4"
 dependencies = [
+ "dotenvy",
  "libloading",
  "widestring",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ exclude = [
 [dependencies]
 libloading = "0.8.1"
 widestring = "1.0.2"
+
+[dev-dependencies]
+dotenvy = "0.15.7"

--- a/examples/discover.rs
+++ b/examples/discover.rs
@@ -1,0 +1,22 @@
+extern crate stm32cubeprog_rs;
+
+use std::env;
+use std::error::Error;
+
+// TODO: Fix slice from raw parts when no ST-Link is connected
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv()?;
+
+    let stm32prog_path = env::var("CUBE_API_DIR")?;
+
+    // Load STM32CubeProgmmer API library
+    let stm32prog = stm32cubeprog_rs::STM32CubeProg::new(stm32prog_path)?;
+
+    // Find connected STLinks
+    let mut stlinks = stm32prog.discover()?;
+    for stlink in stlinks.iter_mut() {
+        println!("{stlink}");
+    }
+
+    Ok(())
+}

--- a/examples/reset_target.rs
+++ b/examples/reset_target.rs
@@ -1,0 +1,30 @@
+extern crate stm32cubeprog_rs;
+
+use std::env;
+use std::error::Error;
+
+// TODO: Fix slice from raw parts when no ST-Link is connected
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv()?;
+
+    let stm32prog_path = env::var("CUBE_API_DIR")?;
+
+    // Load STM32CubeProgmmer API library
+    let stm32prog = stm32cubeprog_rs::STM32CubeProg::new(stm32prog_path)?;
+
+    // Find connected STLinks
+    let mut stlinks = stm32prog.discover()?;
+
+    for stlink in stlinks.iter_mut() {
+        println!("{stlink}");
+
+        // Connect the STlink
+        stm32prog.connect(stlink)?;
+
+        // Reset and disconnect the STLink
+        stm32prog.reset(stlink)?;
+        stm32prog.disconnect();
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Hi!

I added some small changes to avoid calling from_raw_parts when there is null ptr.
How is your general experience with discovering ST-Links? I tried the `discover` example I added multiple times in a row. Sometimes the ST-Link is detected, sometimes not. It is unstable on my machine. I have version 2.14 of the CubeProgrammer.

Which version did you use for testing?

Greetings, Christian